### PR TITLE
[#8] hotfix : drag & drop qusetionItemListAtomFamily 데이터 맞지 않는 오류 수정

### DIFF
--- a/components/survey/template/SelectOptionContainer.tsx
+++ b/components/survey/template/SelectOptionContainer.tsx
@@ -47,7 +47,7 @@ const SelectOptionContainer = ({
 
   const addQuestionItem = useRecoilCallback(({ snapshot, set }) => () => {
     const questionItemIds = snapshot.getLoadable(qusetionItemIdListAtom(SyscodeFormat)).getValue();
-    const lastNumber = questionItemIds[questionItemIds.length - 1].slice(-1);
+    const lastNumber = questionItemIds.length;
     set(qusetionItemIdListAtom(SyscodeFormat), [
       ...questionItemIds,
       `${SyscodeFormat}${Number(lastNumber) + 1}`,

--- a/states/survey.ts
+++ b/states/survey.ts
@@ -5,7 +5,13 @@ import {
   targetQuestionListIDAtom,
 } from 'states/surveyIds';
 import { atom, atomFamily, selector, selectorFamily } from 'recoil';
-import { QuestionIDFormat, PartIDFormat, QuestionListIDFormat, QuestionItemIDFormat } from 'utills/getDateSixth';
+import {
+  QuestionIDFormat,
+  PartIDFormat,
+  QuestionListIDFormat,
+  QuestionItemIDFormat,
+  QuestionItemListUniqueNumber,
+} from 'utills/getDateSixth';
 import {
   IQuestionItem,
   IQuestion,
@@ -211,10 +217,12 @@ export const surveySelector = selector({
 
         //item의idList
         const questionItemIdList = get(qusetionItemIdListAtom(SyscodeFormat));
-        const questionItem = questionItemIdList.map((_, questionItemIdx) => {
+        const questionItem = questionItemIdList.map((questionItemIdx) => {
           //item 아톰 패밀리를 가져와서 리턴
           return get(
-            qusetionItemListAtomFamily(QuestionItemIDFormat(sectionIdx + 1, questionIdx + 1, questionItemIdx + 1))
+            qusetionItemListAtomFamily(
+              QuestionItemIDFormat(sectionIdx + 1, questionIdx + 1, QuestionItemListUniqueNumber(questionItemIdx))
+            )
           );
         });
         //question을 가져와서 questionItem을 담아서 리턴

--- a/utills/getDateSixth.ts
+++ b/utills/getDateSixth.ts
@@ -1,4 +1,4 @@
-import { QuestionListID, SectionID, QuestionID, QuestionItemID } from 'types/survey';
+import { QuestionListID, SectionID, QuestionID, QuestionItemID, QuestionItemListID } from 'types/survey';
 
 export const getDateSixDigitsFormatToday = (): number => {
   const date = new Date();
@@ -46,3 +46,9 @@ export const QuestionItemIDFormat = (partId: number, questionId: number, idx: nu
 
 export const QuestionItemListIDFormat = (partIndex: number, questionIdx: number) =>
   `${PartIDFormat(partIndex)}${QuestionIDFormat(questionIdx, partIndex)}`;
+
+export const QuestionItemListUniqueNumber = (qustionItemListId: QuestionItemListID) => {
+  const splittedQuestionItemListId = qustionItemListId.split('A');
+  const uniqueNumber = splittedQuestionItemListId[splittedQuestionItemListId.length - 1];
+  return Number(uniqueNumber);
+};


### PR DESCRIPTION
1. utills/getDateSixth.ts
- QuestionItemListUniqueNumber: QuestionItemList의 A 이후 숫자를 return 하는 함수
- QustionItemListId와 QustionItem의 ID를 서로 맞추기 위한 함수

2. states/survey.ts
- surveySelector 내부에서, qusetionItemListAtomFamily를 생성할 때, QuestionItemListUniqueNumber 사용
- drag & drop으로 질문 아이템 순서가 바뀌면 변경된 questionItemIdList 순서에 대응되도록 하기 위함

3. components/survey/template/SelectOptionContainer.tsx
- lastNumber를 questionItemIds 길이만큼 정의하도록 수정
- drag&drop으로 순서를 변경했을 때 마지막 요소를 기준으로 새 질문 아이템을 생성하면 오류가 발생하여 수정