### PR TITLE
[#19] bugfix : useScrollheight.tsx useRef 추가

### DIFF
--- a/hooks/useScrollHeight.tsx
+++ b/hooks/useScrollHeight.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 interface IProps {
@@ -7,19 +7,21 @@ interface IProps {
 
 const useScrollHeight = ({ id }: IProps) => {
   const [sectionHeight, setSectionHeight] = useState<number | undefined>(0);
+  const targetElement = useRef<HTMLElement>(null);
 
   useEffect(() => {
-    const height = document.getElementById(id)?.getBoundingClientRect().top;
+    if (targetElement.current === null) return;
+    const height = targetElement.current.getBoundingClientRect().top;
     console.log('height', height);
 
     setSectionHeight(height);
-  }, []);
+  }, [targetElement.current]);
 
   const Section = styled.section`
     height: calc(100% - ${sectionHeight}px);
   `;
 
-  return Section;
+  return [targetElement, Section];
 };
 
 export default useScrollHeight;


### PR DESCRIPTION
전달받은 id 선택자를 가지는 DOM을 불러오지 않는 버그
hook이 return하는 targetElement를 원하는 element에 ref attribute에 할당하여 사용
useEffect의 Dependency Array에 해당 ref를 바라보는 Element 지정